### PR TITLE
Fix AoT compilation without changing seed.config.ts

### DIFF
--- a/src/client/app/app.module.ts
+++ b/src/client/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { APP_BASE_HREF } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { HttpModule } from '@angular/http';
+import { MaterialModule } from '@angular/material';
 import { AppComponent } from './app.component';
 import { routes } from './app.routes';
 
@@ -11,7 +12,8 @@ import { HomeModule } from './home/home.module';
 import { SharedModule } from './shared/shared.module';
 
 @NgModule({
-  imports: [BrowserModule, HttpModule, RouterModule.forRoot(routes), AboutModule, HomeModule, SharedModule.forRoot()],
+  imports: [BrowserModule, HttpModule, RouterModule.forRoot(routes), MaterialModule.forRoot(),
+            AboutModule, HomeModule, SharedModule.forRoot()],
   declarations: [AppComponent],
   providers: [{
     provide: APP_BASE_HREF,

--- a/src/client/app/shared/shared.module.ts
+++ b/src/client/app/shared/shared.module.ts
@@ -13,7 +13,7 @@ import { NameListService } from './name-list/index';
  */
 
 @NgModule({
-  imports: [CommonModule, RouterModule, MaterialModule.forRoot()],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [ToolbarModule, NavbarModule, MaterialModule,
     CommonModule, FormsModule, RouterModule]
 })

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -1,6 +1,3 @@
-/* Import Material Theme */
-@import '/node_modules/@angular/material/core/theming/prebuilt/indigo-pink.css';
-
 /* Reset */
 html,
 body,

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -20,7 +20,13 @@ export class ProjectConfig extends SeedConfig {
     // Add `NPM` third-party libraries to be injected/bundled.
     this.NPM_DEPENDENCIES = [
       ...this.NPM_DEPENDENCIES,
+
+      /* Select a pre-built Material theme */
       {src: '@angular/material/core/theming/prebuilt/indigo-pink.css', inject: true},
+
+      /* HammerJS is required if the app uses certain Material components (eg: md-slider and md-slide-toggle) */
+      //{src: 'hammerjs/hammer.min.js', inject: 'libs'},
+
       // {src: 'jquery/dist/jquery.min.js', inject: 'libs'},
       // {src: 'lodash/lodash.min.js', inject: 'libs'},
     ];

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -20,6 +20,7 @@ export class ProjectConfig extends SeedConfig {
     // Add `NPM` third-party libraries to be injected/bundled.
     this.NPM_DEPENDENCIES = [
       ...this.NPM_DEPENDENCIES,
+      {src: '@angular/material/core/theming/prebuilt/indigo-pink.css', inject: true},
       // {src: 'jquery/dist/jquery.min.js', inject: 'libs'},
       // {src: 'lodash/lodash.min.js', inject: 'libs'},
     ];
@@ -33,6 +34,17 @@ export class ProjectConfig extends SeedConfig {
 
     /* Add to or override NPM module configurations: */
     // this.mergeObject(this.PLUGIN_CONFIGS['browser-sync'], { ghostMode: false });
+
+    // add Material configuration to SystemJS.
+    this.addPackageBundles({
+      name:'@angular/material',
+      path:'node_modules/@angular/material/material.umd.js',
+      packageMeta:{
+        main: 'index.js',
+        defaultExtension: 'js'
+      }
+    });
+
   }
 
 }

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -51,6 +51,9 @@ export class ProjectConfig extends SeedConfig {
       }
     });
 
+    //packageConfigPaths cause app to break in some environments
+    delete this.SYSTEM_CONFIG_DEV.packageConfigPaths;
+
   }
 
 }

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -83,9 +83,9 @@ export class SeedConfig {
   COVERAGE_PORT = argv['coverage-port'] || 4004;
 
   /**
-  * The path to the coverage output
-  * NB: this must match what is configured in ./karma.conf.js
-  */
+   * The path to the coverage output
+   * NB: this must match what is configured in ./karma.conf.js
+   */
   COVERAGE_DIR = 'coverage';
 
   /**
@@ -332,7 +332,7 @@ export class SeedConfig {
    */
   get DEPENDENCIES(): InjectableDependency[] {
     return normalizeDependencies(this.NPM_DEPENDENCIES.filter(filterDependency.bind(null, this.ENV)))
-      .concat(this.APP_ASSETS.filter(filterDependency.bind(null, this.ENV)));
+        .concat(this.APP_ASSETS.filter(filterDependency.bind(null, this.ENV)));
   }
 
   /**
@@ -357,9 +357,9 @@ export class SeedConfig {
       '@angular/core/testing': 'node_modules/@angular/core/bundles/core-testing.umd.js',
       '@angular/http/testing': 'node_modules/@angular/http/bundles/http-testing.umd.js',
       '@angular/platform-browser/testing':
-        'node_modules/@angular/platform-browser/bundles/platform-browser-testing.umd.js',
+          'node_modules/@angular/platform-browser/bundles/platform-browser-testing.umd.js',
       '@angular/platform-browser-dynamic/testing':
-        'node_modules/@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
+          'node_modules/@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
       '@angular/router/testing': 'node_modules/@angular/router/bundles/router-testing.umd.js',
 
       'app/*': '/app/*',
@@ -384,9 +384,10 @@ export class SeedConfig {
    */
   SYSTEM_BUILDER_CONFIG: any = {
     defaultJSExtensions: true,
+    base: this.PROJECT_ROOT,
     packageConfigPaths: [
-      join(this.PROJECT_ROOT, 'node_modules', '*', 'package.json'),
-      join(this.PROJECT_ROOT, 'node_modules', '@angular', '*', 'package.json'),
+      join('node_modules', '*', 'package.json'),
+      join('node_modules', '@angular', '*', 'package.json')
     ],
     paths: {
       // Note that for multiple apps this configuration need to be updated
@@ -433,14 +434,8 @@ export class SeedConfig {
         main: 'index.js',
         defaultExtension: 'js'
       },
-      '@angular/material': {
-        main: 'index.js',
-        defaultExtension: 'js'
-      },
       'rxjs': {
-        defaultExtension: 'js'
-      },
-      '.': {
+        main: 'Rx.js',
         defaultExtension: 'js'
       }
     }
@@ -569,8 +564,8 @@ export class SeedConfig {
  */
 export function normalizeDependencies(deps: InjectableDependency[]) {
   deps
-    .filter((d: InjectableDependency) => !/\*/.test(d.src)) // Skip globs
-    .forEach((d: InjectableDependency) => d.src = require.resolve(d.src));
+      .filter((d: InjectableDependency) => !/\*/.test(d.src)) // Skip globs
+      .forEach((d: InjectableDependency) => d.src = require.resolve(d.src));
   return deps;
 }
 

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -351,7 +351,6 @@ export class SeedConfig {
       '@angular/platform-browser': 'node_modules/@angular/platform-browser/bundles/platform-browser.umd.js',
       '@angular/platform-browser-dynamic': 'node_modules/@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
       '@angular/router': 'node_modules/@angular/router/bundles/router.umd.js',
-      '@angular/material': 'node_modules/@angular/material/material.umd.js',
 
       '@angular/common/testing': 'node_modules/@angular/common/bundles/common-testing.umd.js',
       '@angular/compiler/testing': 'node_modules/@angular/compiler/bundles/compiler-testing.umd.js',
@@ -395,7 +394,6 @@ export class SeedConfig {
       // `src/client`.
       [join(this.TMP_DIR, this.BOOTSTRAP_DIR, '*')]: `${this.TMP_DIR}/${this.BOOTSTRAP_DIR}/*`,
       'node_modules/*': 'node_modules/*',
-      'dist/tmp/node_modules/*': 'dist/tmp/node_modules/*',
       '*': 'node_modules/*'
     },
     packages: {

--- a/tools/tasks/project/compile.ahead.prod.ts
+++ b/tools/tasks/project/compile.ahead.prod.ts
@@ -14,17 +14,17 @@ function codegen(
   return CodeGenerator.create(ngOptions, cliOptions, program, host).codegen();
 }
 
-const modifyFile = (path: string, mod: any = (f: string) => f) => {
-  const file = readFileSync(path);
-  writeFileSync(path, mod(file.toString()));
+const copyFile = (name: string, from: string, to: string, mod: any = (f: string) => f) => {
+    const file = readFileSync(join(from, name));
+    writeFileSync(join(to, name), mod(file.toString()));
 };
 
 export = (done: any) => {
   // Note: dirty hack until we're able to set config easier
-  modifyFile(join(Config.TMP_DIR, 'tsconfig.json'), (content: string) => {
+  copyFile('tsconfig.json', Config.TMP_DIR, join(Config.TMP_DIR, Config.BOOTSTRAP_DIR), (content: string) => {
     const parsed = JSON.parse(content);
     parsed.files = parsed.files || [];
-    parsed.files.push(join(Config.BOOTSTRAP_DIR, 'main.ts'));
+    parsed.files.push('main.ts');
     return JSON.stringify(parsed, null, 2);
   });
   const args = argv;
@@ -37,7 +37,7 @@ export = (done: any) => {
   }
 
   const cliOptions = new tsc.NgcCliOptions(args);
-  tsc.main(Config.TMP_DIR, cliOptions, codegen)
+  tsc.main(join(Config.TMP_DIR, Config.BOOTSTRAP_DIR), cliOptions, codegen)
     .then(done)
     .catch(e => {
       console.error(e.stack);


### PR DESCRIPTION
This is in response to [this comment](https://github.com/DeviantJS/angular2-seed-material2/issues/72#issuecomment-255593215)

If all you care about is fixing the error mentioned at that comment, just look at how I changed `compile.ahead.prod`

Broadly speaking, I tried to change your seed to more closely match what I've gotten to work on my own project.
 - I restored `seed.config.ts` to its default and moved modifications to `project.config.ts` so that when root project updates, the mods will not be overwritten
 - I moved `compile.ahead.prod` from `tools/tasks/seed/` to `tools/tasks/project` so that mods will not be overwritten when root project updates.
 - Fixed errors in `compile.ahead.prod` to address  [this error](https://github.com/DeviantJS/angular2-seed-material2/issues/72#issuecomment-255593215.
 - Removed `@import` of Material theme from `main.css` and added Material theme as a dependency in `project.config.ts`. This way Even projects that do not use `main.css` will work.
 - Added `HammerJS` to `project.config.ts` (commented out) because it will be required by projects that use certain material components.